### PR TITLE
feat: add markdown line wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ The prettier config used by all ORY projects.
 
 # GitHub Action
 
-This also defines a GitHub action to use for format checking.
-Usage similar to:
+This also defines a GitHub action to use for format checking. Usage similar to:
 
 ```yaml
 name: Check format
@@ -23,5 +22,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ory/prettier-styles@v1.0.1
+      - uses: ory/prettier-styles@v1
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "prettier.config.js",
   "scripts": {
     "test": "tsc --noEmit && prettier --check prettier.config.ts",
-    "format": "tsc && prettier --write prettier.config.ts",
+    "format": "tsc && prettier --write \"{prettier.config.ts,README.md}\"",
     "build": "tsc"
   },
   "repository": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,6 +3,7 @@ exports.__esModule = true;
 var options = {
     trailingComma: 'none',
     semi: false,
-    singleQuote: true
+    singleQuote: true,
+    proseWrap: 'always'
 };
 module.exports = options;

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -3,7 +3,8 @@ import { Options } from 'prettier'
 const options: Options = {
   trailingComma: 'none',
   semi: false,
-  singleQuote: true
+  singleQuote: true,
+  proseWrap: 'always'
 }
 
 module.exports = options


### PR DESCRIPTION
This option is required to enable markdown line wrapping. For mor information have a look at https://prettier.io/docs/en/options.html#prose-wrap