### PR TITLE
ci: Install Prettier only if needed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,12 +8,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Prettier if it doesn't exist
-      run: |-
-        if [ ! -f node_modules/.bin/prettier ]; then
-          bash <(curl -s https://raw.githubusercontent.com/ory/ci/master/src/scripts/install/prettier.sh)
-        fi
-      shell: bash
     - name: Check
-      run: npm run $INPUT_NPMRUNARGS
+      run: npx prettier --check .
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,10 @@ inputs:
   npmRunArgs:
     description: The args passed to `npm run`
     required: false
-    default: format:check
+    default: npx prettier --check .
 runs:
   using: composite
   steps:
     - name: Prettier
-      run: npx prettier --check .
+      run: $INPUT_NPMRUNARGS
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: |-
-        bash <(curl -s https://raw.githubusercontent.com/ory/ci/master/src/scripts/install/prettier.sh)
-        npm run $INPUT_NPMRUNARGS
+    - name: Install Prettier if it doesn't exist
+      run: |-
+        if [ ! -f node_modules/.bin/prettier ]; then
+          bash <(curl -s https://raw.githubusercontent.com/ory/ci/master/src/scripts/install/prettier.sh)
+        fi
+      shell: bash
+    - name: Check
+      run: npm run $INPUT_NPMRUNARGS
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check
+    - name: Prettier
       run: npx prettier --check .
       shell: bash


### PR DESCRIPTION
Not sure if this is needed but it doesn't hurt to have this logic. It makes this GitHub Action usable in larger workflows where Prettier is already installed. 

Tested manually.