### PR TITLE
feat: restore standard formatting for Markdown

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,14 +2,17 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation
-in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity,
-sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment include:
+Examples of behavior that contributes to creating a positive environment
+include:
 
 - Using welcoming and inclusive language
 - Being respectful of differing viewpoints and experiences
@@ -19,43 +22,56 @@ Examples of behavior that contributes to creating a positive environment include
 
 Examples of unacceptable behavior by participants include:
 
-- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
 - Trolling, insulting/derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or electronic address, without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and
-fair corrective action in response to any instances of unacceptable behavior.
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and
-other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other
-behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its
-community. Examples of representing a project or community include using an official project e-mail address, posting via an
-official social media account, or acting as an appointed representative at an online or offline event. Representation of a project
-may be further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at
-office@ory.sh. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and
-appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an
-incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at office@ory.sh. All complaints will be
+reviewed and investigated and will result in a response that is deemed necessary
+and appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions
-as determined by other members of the project's leadership.
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
 https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,36 +28,47 @@ https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING
 
 ## Introduction
 
-There are many ways in which you can contribute, beyond writing code. The goal of this document is to provide a high-level
-overview of how you can get involved.
+There are many ways in which you can contribute, beyond writing code. The goal
+of this document is to provide a high-level overview of how you can get
+involved.
 
-_Please note_: We take Ory Prettier Styles's security and our users' trust very seriously. If you believe you have found a
-security issue in Ory Prettier Styles, please responsibly disclose by contacting us at security@ory.sh.
+_Please note_: We take Ory Prettier Styles's security and our users' trust very
+seriously. If you believe you have found a security issue in Ory Prettier
+Styles, please responsibly disclose by contacting us at security@ory.sh.
 
-First: As a potential contributor, your changes and ideas are welcome at any hour of the day or night, weekdays, weekends, and
-holidays. Please do not ever hesitate to ask a question or send a pull request.
+First: As a potential contributor, your changes and ideas are welcome at any
+hour of the day or night, weekdays, weekends, and holidays. Please do not ever
+hesitate to ask a question or send a pull request.
 
-If you are unsure, just ask or submit the issue or pull request anyways. You won't be yelled at for giving it your best effort.
-The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contributions, and don't
-want a wall of rules to get in the way of that.
+If you are unsure, just ask or submit the issue or pull request anyways. You
+won't be yelled at for giving it your best effort. The worst that can happen is
+that you'll be politely asked to change something. We appreciate any sort of
+contributions, and don't want a wall of rules to get in the way of that.
 
-That said, if you want to ensure that a pull request is likely to be merged, talk to us! You can find out our thoughts and ensure
-that your contribution won't clash or be obviated by Ory Prettier Styles's normal direction. A great way to do this is via
-[Ory Prettier Styles Discussions](https://github.com/orgs/ory/discussions) or the [Ory Chat](https://www.ory.sh/chat).
+That said, if you want to ensure that a pull request is likely to be merged,
+talk to us! You can find out our thoughts and ensure that your contribution
+won't clash or be obviated by Ory Prettier Styles's normal direction. A great
+way to do this is via
+[Ory Prettier Styles Discussions](https://github.com/orgs/ory/discussions) or
+the [Ory Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
 - I am new to the community. Where can I find the
   [Ory Community Code of Conduct?](https://github.com/ory/prettier-styles/blob/master/CODE_OF_CONDUCT.md)
 
-- I have a question. Where can I get [answers to questions regarding Ory Prettier Styles?](#communication)
+- I have a question. Where can I get
+  [answers to questions regarding Ory Prettier Styles?](#communication)
 
-- I would like to contribute but I am not sure how. Are there [easy ways to contribute?](#how-can-i-contribute)
+- I would like to contribute but I am not sure how. Are there
+  [easy ways to contribute?](#how-can-i-contribute)
   [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
 
-- I want to talk to other Ory Prettier Styles users. [How can I become a part of the community?](#communication)
+- I want to talk to other Ory Prettier Styles users.
+  [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to Ory Prettier Styles. Does Ory have
+- I would like to know what I am agreeing to when I contribute to Ory Prettier
+  Styles. Does Ory have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/prettier-styles)
 
 - I would like updates about new versions of Ory Prettier Styles.
@@ -68,65 +79,82 @@ that your contribution won't clash or be obviated by Ory Prettier Styles's norma
 If you want to start contributing code right away, we have a
 [list of good first issues](https://github.com/ory/prettier-styles/labels/good%20first%20issue).
 
-There are many other ways you can contribute without writing any code. Here are a few things you can do to help out:
+There are many other ways you can contribute without writing any code. Here are
+a few things you can do to help out:
 
-- **Give us a star.** It may not seem like much, but it really makes a difference. This is something that everyone can do to help
-  out Ory Prettier Styles. Github stars help the project gain visibility and stand out.
+- **Give us a star.** It may not seem like much, but it really makes a
+  difference. This is something that everyone can do to help out Ory Prettier
+  Styles. Github stars help the project gain visibility and stand out.
 
-- **Join the community.** Sometimes helping people can be as easy as listening to their problems and offering a different
-  perspective. Join our Slack, have a look at discussions in the forum and take part in our weekly hangout. More info on this in
-  [Communication](#communication).
+- **Join the community.** Sometimes helping people can be as easy as listening
+  to their problems and offering a different perspective. Join our Slack, have a
+  look at discussions in the forum and take part in our weekly hangout. More
+  info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for Ory Prettier Styles and some of them may lack necessary
-  information, some are duplicates of older issues. You can help out by guiding people through the process of filling out the
-  issue template, asking for clarifying information, or pointing them to existing issues that match their description of the
-  problem.
+- **Helping with open issues.** We have a lot of open issues for Ory Prettier
+  Styles and some of them may lack necessary information, some are duplicates of
+  older issues. You can help out by guiding people through the process of
+  filling out the issue template, asking for clarifying information, or pointing
+  them to existing issues that match their description of the problem.
 
-- **Reviewing documentation changes.** Most documentation just needs a review for proper spelling and grammar. If you think a
-  document can be improved in any way, feel free to hit the `edit` button at the top of the page. More info on contributing to
-  documentation [here](#documentation).
+- **Reviewing documentation changes.** Most documentation just needs a review
+  for proper spelling and grammar. If you think a document can be improved in
+  any way, feel free to hit the `edit` button at the top of the page. More info
+  on contributing to documentation [here](#documentation).
 
-- **Help with tests.** Some pull requests may lack proper tests or test plans. These are needed for the change to be implemented
-  safely.
+- **Help with tests.** Some pull requests may lack proper tests or test plans.
+  These are needed for the change to be implemented safely.
 
 ## Communication
 
-We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask questions, discuss bugs and feature requests, talk to
-other users of Ory, etc.
+We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
+questions, discuss bugs and feature requests, talk to other users of Ory, etc.
 
-Check out [Ory Prettier Styles Discussions](https://github.com/orgs/ory/discussions). This is a great place for in-depth
-discussions and lots of code examples, logs and similar data.
+Check out
+[Ory Prettier Styles Discussions](https://github.com/orgs/ory/discussions). This
+is a great place for in-depth discussions and lots of code examples, logs and
+similar data.
 
-You can also join our community hangout, if you want to speak to the Ory team directly or ask some questions. You can find more
-info on the hangouts in [Slack](https://www.ory.sh/chat).
+You can also join our community hangout, if you want to speak to the Ory team
+directly or ask some questions. You can find more info on the hangouts in
+[Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to Ory Prettier Styles, consider joining the mailing list. We will
-_only_ send you vital information on the projects that you are interested in.
+If you want to receive regular notifications about updates to Ory Prettier
+Styles, consider joining the mailing list. We will _only_ send you vital
+information on the projects that you are interested in.
 
 Also [follow us on twitter](https://twitter.com/orycorp).
 
 ## Contributing Code
 
-Unless you are fixing a known bug, we **strongly** recommend discussing it with the core team via a GitHub issue or
-[in our chat](https://www.ory.sh/chat) before getting started to ensure your work is consistent with Ory Prettier Styles's roadmap
-and architecture.
+Unless you are fixing a known bug, we **strongly** recommend discussing it with
+the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
+before getting started to ensure your work is consistent with Ory Prettier
+Styles's roadmap and architecture.
 
-All contributions are made via pull requests. To make a pull request, you will need a GitHub account; if you are unclear on this
-process, see GitHub's documentation on [forking](https://help.github.com/articles/fork-a-repo) and
-[pull requests](https://help.github.com/articles/using-pull-requests). Pull requests should be targeted at the `master` branch.
-Before creating a pull request, go through this checklist:
+All contributions are made via pull requests. To make a pull request, you will
+need a GitHub account; if you are unclear on this process, see GitHub's
+documentation on [forking](https://help.github.com/articles/fork-a-repo) and
+[pull requests](https://help.github.com/articles/using-pull-requests). Pull
+requests should be targeted at the `master` branch. Before creating a pull
+request, go through this checklist:
 
 1. Create a feature branch off of `master` so that changes do not get mixed up.
-1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local changes against the `master` branch.
-1. Run the full project test suite with the `go test -tags sqlite ./...` (or equivalent) command and confirm that it passes.
-1. Run `make format` if a `Makefile` is available, `gofmt -s` if the project is written in Go, `npm run format` if the project is
-   written for NodeJS.
-1. Ensure that each commit has a descriptive prefix. This ensures a uniform commit history and helps structure the changelog.  
+1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local
+   changes against the `master` branch.
+1. Run the full project test suite with the `go test -tags sqlite ./...` (or
+   equivalent) command and confirm that it passes.
+1. Run `make format` if a `Makefile` is available, `gofmt -s` if the project is
+   written in Go, `npm run format` if the project is written for NodeJS.
+1. Ensure that each commit has a descriptive prefix. This ensures a uniform
+   commit history and helps structure the changelog.  
    Please refer to this
-   [list of prefixes for Prettier Styles](https://github.com/ory/prettier-styles/blob/master/.github/semantic.yml) for an
-   overview.
-1. Sign-up with CircleCI so that it has access to your repository with the branch containing your PR. Simply creating a CircleCI
-   account is sufficient for the CI jobs to run, you do not need to setup a CircleCI project for the branch.
+   [list of prefixes for Prettier Styles](https://github.com/ory/prettier-styles/blob/master/.github/semantic.yml)
+   for an overview.
+1. Sign-up with CircleCI so that it has access to your repository with the
+   branch containing your PR. Simply creating a CircleCI account is sufficient
+   for the CI jobs to run, you do not need to setup a CircleCI project for the
+   branch.
 
 If a pull request is not ready to be reviewed yet
 [it should be marked as a "Draft"](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request).
@@ -134,46 +162,55 @@ If a pull request is not ready to be reviewed yet
 Before your contributions can be reviewed you need to sign our
 [Contributor License Agreement](https://cla-assistant.io/ory/prettier-styles).
 
-This agreement defines the terms under which your code is contributed to Ory. More specifically it declares that you have the
-right to, and actually do, grant us the rights to use your contribution. You can see the Apache 2.0 license under which our
-projects are published [here](https://github.com/ory/meta/blob/master/LICENSE).
+This agreement defines the terms under which your code is contributed to Ory.
+More specifically it declares that you have the right to, and actually do, grant
+us the rights to use your contribution. You can see the Apache 2.0 license under
+which our projects are published
+[here](https://github.com/ory/meta/blob/master/LICENSE).
 
-When pull requests fail testing, authors are expected to update their pull requests to address the failures until the tests pass.
+When pull requests fail testing, authors are expected to update their pull
+requests to address the failures until the tests pass.
 
 Pull requests eligible for review
 
 1. follow the repository's code formatting conventions;
-2. include tests which prove that the change works as intended and does not add regressions;
+2. include tests which prove that the change works as intended and does not add
+   regressions;
 3. document the changes in the code and/or the project's documentation;
 4. pass the CI pipeline;
-5. have signed our [Contributor License Agreement](https://cla-assistant.io/ory/prettier-styles);
+5. have signed our
+   [Contributor License Agreement](https://cla-assistant.io/ory/prettier-styles);
 6. include a proper git commit message following the
    [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
 
-If all of these items are checked, the pull request is ready to be reviewed and you should change the status to "Ready for review"
-and
+If all of these items are checked, the pull request is ready to be reviewed and
+you should change the status to "Ready for review" and
 [request review from a maintainer](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).
 
 Reviewers will approve the pull request once they are satisfied with the patch.
 
 ## Documentation
 
-Please provide documentation when changing, removing, or adding features. Documentation resides in the project's
-[docs](https://github.com/ory/prettier-styles/tree/master/docs) folder. Generate API and configuration reference documentation
-using `cd docs; npm run gen`.
+Please provide documentation when changing, removing, or adding features.
+Documentation resides in the project's
+[docs](https://github.com/ory/prettier-styles/tree/master/docs) folder. Generate
+API and configuration reference documentation using `cd docs; npm run gen`.
 
-For further instructions please head over to [docs/README.md](https://github.com/ory/prettier-styles/blob/master/README.md).
+For further instructions please head over to
+[docs/README.md](https://github.com/ory/prettier-styles/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 
-Please disclose vulnerabilities exclusively to [security@ory.sh](mailto:security@ory.sh). Do not use GitHub issues.
+Please disclose vulnerabilities exclusively to
+[security@ory.sh](mailto:security@ory.sh). Do not use GitHub issues.
 
 ## Code Style
 
 Please follow these guidelines when formatting source code:
 
 - Go code should match the output of `gofmt -s` and pass `golangci-lint run`.
-- NodeJS and JavaScript code should be prettified using `npm run format` where appropriate.
+- NodeJS and JavaScript code should be prettified using `npm run format` where
+  appropriate.
 
 ### Working with Forks
 
@@ -204,19 +241,25 @@ Now go to the project's GitHub Pull Request page and click "New pull request"
 
 ## Conduct
 
-Whether you are a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your
-back.
+Whether you are a regular contributor or a newcomer, we care about making this
+community a safe place for you and we've got your back.
 
-- We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation,
-  disability, ethnicity, religion, or similar personal characteristic.
-- Please avoid using nicknames that might detract from a friendly, safe and welcoming environment for all.
+- We are committed to providing a friendly, safe and welcoming environment for
+  all, regardless of gender, sexual orientation, disability, ethnicity,
+  religion, or similar personal characteristic.
+- Please avoid using nicknames that might detract from a friendly, safe and
+  welcoming environment for all.
 - Be kind and courteous. There is no need to be mean or rude.
-- We will exclude you from interaction if you insult, demean or harass anyone. In particular, we do not tolerate behavior that
-  excludes people in socially marginalized groups.
-- Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made
-  uncomfortable by a community member, please contact one of the channel ops or a member of the Ory Prettier Styles core team
-  immediately.
-- Likewise any spamming, trolling, flaming, baiting or other attention-stealing behaviour is not welcome.
+- We will exclude you from interaction if you insult, demean or harass anyone.
+  In particular, we do not tolerate behavior that excludes people in socially
+  marginalized groups.
+- Private harassment is also unacceptable. No matter who you are, if you feel
+  you have been or are being harassed or made uncomfortable by a community
+  member, please contact one of the channel ops or a member of the Ory Prettier
+  Styles core team immediately.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing
+  behaviour is not welcome.
 
-We welcome discussion about creating a welcoming, safe, and productive environment for the community. If you have any questions,
-feedback, or concerns [please let us know](https://www.ory.sh/chat).
+We welcome discussion about creating a welcoming, safe, and productive
+environment for the community. If you have any questions, feedback, or concerns
+[please let us know](https://www.ory.sh/chat).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,8 +21,8 @@ https://github.com/ory/meta/blob/master/templates/repository/SECURITY.md
 
 ## Supported Versions
 
-We release patches for security vulnerabilities. Which versions are eligible receiving such patches depend on the CVSS v3.0
-Rating:
+We release patches for security vulnerabilities. Which versions are eligible
+receiving such patches depend on the CVSS v3.0 Rating:
 
 | CVSS v3.0 | Supported Versions                        |
 | --------- | ----------------------------------------- |
@@ -31,6 +31,7 @@ Rating:
 
 ## Reporting a Vulnerability
 
-Please report (suspected) security vulnerabilities to **[security@ory.sh](mailto:security@ory.sh)**. You will receive a response
-from us within 48 hours. If the issue is confirmed, we will release a patch as soon as possible depending on complexity but
-historically within a few days.
+Please report (suspected) security vulnerabilities to
+**[security@ory.sh](mailto:security@ory.sh)**. You will receive a response from
+us within 48 hours. If the issue is confirmed, we will release a patch as soon
+as possible depending on complexity but historically within a few days.

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,9 +1,9 @@
 'use strict'
 exports.__esModule = true
 var options = {
-    trailingComma: 'none',
-    semi: false,
-    singleQuote: true,
-    proseWrap: 'always'
-};
-module.exports = options;
+  trailingComma: 'none',
+  semi: false,
+  singleQuote: true,
+  proseWrap: 'always'
+}
+module.exports = options

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,14 +4,6 @@ var options = {
     trailingComma: 'none',
     semi: false,
     singleQuote: true,
-    proseWrap: 'always',
-    overrides: [
-        {
-            files: ['*.md', '*.mdx'],
-            options: {
-                printWidth: 130
-            }
-        }
-    ]
+    proseWrap: 'always'
 };
 module.exports = options;

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -4,15 +4,7 @@ const options: Options = {
   trailingComma: 'none',
   semi: false,
   singleQuote: true,
-  proseWrap: 'always',
-  overrides: [
-    {
-      files: ['*.md', '*.mdx'],
-      options: {
-        printWidth: 130
-      }
-    }
-  ]
+  proseWrap: 'always'
 }
 
 module.exports = options


### PR DESCRIPTION
#38 introduces a wider print-width for Markdown files in all 247 Ory repos. I suggest to stick with the standard print width (80 characters) as the default setting. We can easily override this setting on an as-needed basis in repos that really need wider widths. An example for such an override is https://github.com/ory/docs/pull/862. That repo seems the only one really needing the 130 chars width right now.

There are many reasons why so many programming languages stick to 80 characters:

- Such wide content forces everybody working on Markdown to have their IDE in fullscreen on laptops and smaller monitors. Not everybody can or wants to do that. Examples are reviewing code (where one sees two columns of MD side by side) or when editing Markdown and having a browser window showing a preview of the rendered webpage next to your IDE.
- When text gets too wide, it becomes less ergonomic to read. For example, it becomes harder to find the beginning of the next line. Some people get tremors moving their field of vision left and right repeatedly.
- Text with 130 chars is a disaster to read or write on mobile.
- Some tools have a built-in assumption that content is 80 characters wide. As an example, GMail hard-wraps text at 80 characters in plain-text mode. There are many ways in which Markdown source can end up in an email.
- Working on any MD file in any repo is painful to impossible in the current state where the configured width is 130 but almost all repos are still at 80 chars. Each time I make a change anywhere, my IDE reformats all content to 130. This obfuscates my actual changes. People will lose work because of this.
- We can't really reformat all 247 repos because that wouldn't be time well spent and it will destroy the ability to `git blame` Markdown files. Knowing who worked last on which line is important for maintenance of the documentation, for example when finding out who to reach out to when changing or removing on existing content.
