### PR TITLE
style: leverage TS modules as namespaces

### DIFF
--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,6 +1,6 @@
-import { Options } from 'prettier'
+import * as prettier from 'prettier'
 
-const options: Options = {
+const options: prettier.Options = {
   trailingComma: 'none',
   semi: false,
   singleQuote: true,


### PR DESCRIPTION
This is [officially supported](https://www.typescriptlang.org/docs/handbook/modules.html#import-the-entire-module-into-a-single-variable-and-use-it-to-access-the-module-exports) and is closer to the way Go works.