### PR TITLE
build: update version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ory-prettier-styles",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ory-prettier-styles",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "devDependencies": {
         "@types/node": "^17.0.33",
         "prettier": "^2.6.2",


### PR DESCRIPTION
Somebody forgot to update package-lock.json when bumping the version last time.