### PR TITLE
ci: remove redundant tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install
         run: npm ci
-      - name: Test
-        run: npm test
       - name: Format
         run: npm run format
       - name: Commit


### PR DESCRIPTION
`npm run format` fixes all fixable issues and errs if there are unfixable ones. It is therefore not necessary to also run `npm run test` here. It does literally the same tests.