### PR TITLE
build: enable strict type checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.0",
       "devDependencies": {
         "@types/node": "^17.0.33",
+        "@types/prettier": "^2.6.3",
         "prettier": "^2.6.2",
         "typescript": "^4.6.4"
       }
@@ -17,6 +18,12 @@
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.33.tgz",
       "integrity": "sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ==",
+      "dev": true
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
+      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
       "dev": true
     },
     "node_modules/prettier": {
@@ -53,6 +60,12 @@
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.33.tgz",
       "integrity": "sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ==",
+      "dev": true
+    },
+    "@types/prettier": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
+      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
       "dev": true
     },
     "prettier": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   },
   "homepage": "https://github.com/ory/prettier-styles",
   "devDependencies": {
+    "@types/node": "^17.0.33",
+    "@types/prettier": "^2.6.3",
     "prettier": "^2.6.2",
-    "typescript": "^4.6.4",
-    "@types/node": "^17.0.33"
+    "typescript": "^4.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "homepage": "https://github.com/ory/prettier-styles",
   "devDependencies": {
-    "@types/node": "^17.0.33",
     "@types/prettier": "^2.6.3",
     "prettier": "^2.6.2",
-    "typescript": "^4.6.4"
+    "typescript": "^4.6.4",
+    "@types/node": "^17.0.33"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
I really like that we use Typescript to verify the Prettier config options here. A problem with the current setup is that TypeScript doesn't know what type `prettier.Options` is and therefore considers it `any`. This means Typescript allows any keys in it, even invalid Prettier configuration values, like `foo: 13`. 

This PR enables TypeScript's strict mode, which prohibits unknown types. I also add the type definitions for Prettier. The new setup successfully rejects invalid keys in the Prettier configuration.