### PR TITLE
feat: use default value for quotes (double-quotes)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,14 +3,14 @@ module.exports = {
     node: true
   },
   extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'prettier' // this must come last
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier" // this must come last
   ],
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
   root: true,
   rules: {
-    'sort-keys': ['error']
+    "sort-keys": ["error"]
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,16 +1,16 @@
 module.exports = {
   env: {
-    node: true
+    node: true,
   },
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier" // this must come last
+    "prettier", // this must come last
   ],
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   root: true,
   rules: {
-    "sort-keys": ["error"]
-  }
+    "sort-keys": ["error"],
+  },
 }

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,17 +1,17 @@
-description: 'Create a bug report'
+description: "Create a bug report"
 labels:
   - bug
-name: 'Bug Report'
+name: "Bug Report"
 body:
   - attributes:
       value: "Thank you for taking the time to fill out this bug report!\n"
     type: markdown
   - attributes:
-      label: 'Preflight checklist'
+      label: "Preflight checklist"
       options:
         - label:
-            'I could not find a solution in the existing issues, docs, nor
-            discussions.'
+            "I could not find a solution in the existing issues, docs, nor
+            discussions."
           required: true
         - label:
             "I agree to follow this project's [Code of
@@ -22,18 +22,18 @@ body:
             Guidelines](https://github.com/ory/prettier-styles/blob/master/CONTRIBUTING.md)."
           required: true
         - label:
-            'This issue affects my [Ory Cloud](https://www.ory.sh/) project.'
+            "This issue affects my [Ory Cloud](https://www.ory.sh/) project."
         - label:
-            'I have joined the [Ory Community Slack](https://slack.ory.sh).'
+            "I have joined the [Ory Community Slack](https://slack.ory.sh)."
         - label:
-            'I am signed up to the [Ory Security Patch
-            Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53).'
+            "I am signed up to the [Ory Security Patch
+            Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)."
     id: checklist
     type: checkboxes
   - attributes:
-      description: 'A clear and concise description of what the bug is.'
-      label: 'Describe the bug'
-      placeholder: 'Tell us what you see!'
+      description: "A clear and concise description of what the bug is."
+      label: "Describe the bug"
+      placeholder: "Tell us what you see!"
     id: describe-bug
     type: textarea
     validations:
@@ -47,17 +47,17 @@ body:
         1. Run `docker run ....`
         2. Make API Request to with `curl ...`
         3. Request fails with response: `{"some": "error"}`
-      label: 'Reproducing the bug'
+      label: "Reproducing the bug"
     id: reproduce-bug
     type: textarea
     validations:
       required: true
   - attributes:
       description:
-        'Please copy and paste any relevant log output. This will be
+        "Please copy and paste any relevant log output. This will be
         automatically formatted into code, so no need for backticks. Please
-        redact any sensitive information'
-      label: 'Relevant log output'
+        redact any sensitive information"
+      label: "Relevant log output"
       render: shell
       placeholder: |
         log=error ....
@@ -65,10 +65,10 @@ body:
     type: textarea
   - attributes:
       description:
-        'Please copy and paste any relevant configuration. This will be
+        "Please copy and paste any relevant configuration. This will be
         automatically formatted into code, so no need for backticks. Please
-        redact any sensitive information!'
-      label: 'Relevant configuration'
+        redact any sensitive information!"
+      label: "Relevant configuration"
       render: yml
       placeholder: |
         server:
@@ -77,14 +77,14 @@ body:
     id: config
     type: textarea
   - attributes:
-      description: 'What version of our software are you running?'
+      description: "What version of our software are you running?"
       label: Version
     id: version
     type: input
     validations:
       required: true
   - attributes:
-      label: 'On which operating system are you observing this issue?'
+      label: "On which operating system are you observing this issue?"
       options:
         - Ory Cloud
         - macOS
@@ -95,19 +95,19 @@ body:
     id: operating-system
     type: dropdown
   - attributes:
-      label: 'In which environment are you deploying?'
+      label: "In which environment are you deploying?"
       options:
         - Ory Cloud
         - Docker
-        - 'Docker Compose'
-        - 'Kubernetes with Helm'
+        - "Docker Compose"
+        - "Kubernetes with Helm"
         - Kubernetes
         - Binary
         - Other
     id: deployment
     type: dropdown
   - attributes:
-      description: 'Add any other context about the problem here.'
+      description: "Add any other context about the problem here."
       label: Additional Context
     id: additional
     type: textarea

--- a/.github/ISSUE_TEMPLATE/DESIGN-DOC.yml
+++ b/.github/ISSUE_TEMPLATE/DESIGN-DOC.yml
@@ -1,8 +1,8 @@
 description:
-  'A design document is needed for non-trivial changes to the code base.'
+  "A design document is needed for non-trivial changes to the code base."
 labels:
   - rfc
-name: 'Design Document'
+name: "Design Document"
 body:
   - attributes:
       value: |
@@ -18,11 +18,11 @@ body:
         after code reviews, and your pull requests will be merged faster.
     type: markdown
   - attributes:
-      label: 'Preflight checklist'
+      label: "Preflight checklist"
       options:
         - label:
-            'I could not find a solution in the existing issues, docs, nor
-            discussions.'
+            "I could not find a solution in the existing issues, docs, nor
+            discussions."
           required: true
         - label:
             "I agree to follow this project's [Code of
@@ -33,18 +33,18 @@ body:
             Guidelines](https://github.com/ory/prettier-styles/blob/master/CONTRIBUTING.md)."
           required: true
         - label:
-            'This issue affects my [Ory Cloud](https://www.ory.sh/) project.'
+            "This issue affects my [Ory Cloud](https://www.ory.sh/) project."
         - label:
-            'I have joined the [Ory Community Slack](https://slack.ory.sh).'
+            "I have joined the [Ory Community Slack](https://slack.ory.sh)."
         - label:
-            'I am signed up to the [Ory Security Patch
-            Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53).'
+            "I am signed up to the [Ory Security Patch
+            Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)."
     id: checklist
     type: checkboxes
   - attributes:
       description: |
         This section gives the reader a very rough overview of the landscape in which the new system is being built and what is actually being built. This isn’t a requirements doc. Keep it succinct! The goal is that readers are brought up to speed but some previous knowledge can be assumed and detailed info can be linked to. This section should be entirely focused on objective background facts.
-      label: 'Context and scope'
+      label: "Context and scope"
     id: scope
     type: textarea
     validations:
@@ -53,7 +53,7 @@ body:
   - attributes:
       description: |
         A short list of bullet points of what the goals of the system are, and, sometimes more importantly, what non-goals are. Note, that non-goals aren’t negated goals like “The system shouldn’t crash”, but rather things that could reasonably be goals, but are explicitly chosen not to be goals. A good example would be “ACID compliance”; when designing a database, you’d certainly want to know whether that is a goal or non-goal. And if it is a non-goal you might still select a solution that provides it, if it doesn’t introduce trade-offs that prevent achieving the goals.
-      label: 'Goals and non-goals'
+      label: "Goals and non-goals"
     id: goals
     type: textarea
     validations:
@@ -65,7 +65,7 @@ body:
         The design doc is the place to write down the trade-offs you made in designing your software. Focus on those trade-offs to produce a useful document with long-term value. That is, given the context (facts), goals and non-goals (requirements), the design doc is the place to suggest solutions and show why a particular solution best satisfies those goals.
 
         The point of writing a document over a more formal medium is to provide the flexibility to express the problem set at hand in an appropriate manner. Because of this, there is no explicit guidance for how to actually describe the design.
-      label: 'The design'
+      label: "The design"
     id: design
     type: textarea
     validations:
@@ -74,21 +74,21 @@ body:
   - attributes:
       description: |
         If the system under design exposes an API, then sketching out that API is usually a good idea. In most cases, however, one should withstand the temptation to copy-paste formal interface or data definitions into the doc as these are often verbose, contain unnecessary detail and quickly get out of date. Instead focus on the parts that are relevant to the design and its trade-offs.
-      label: 'APIs'
+      label: "APIs"
     id: apis
     type: textarea
 
   - attributes:
       description: |
         Systems that store data should likely discuss how and in what rough form this happens. Similar to the advice on APIs, and for the same reasons, copy-pasting complete schema definitions should be avoided. Instead focus on the parts that are relevant to the design and its trade-offs.
-      label: 'Data storage'
+      label: "Data storage"
     id: persistence
     type: textarea
 
   - attributes:
       description: |
         Design docs should rarely contain code, or pseudo-code except in situations where novel algorithms are described. As appropriate, link to prototypes that show the implementability of the design.
-      label: 'Code and pseudo-code'
+      label: "Code and pseudo-code"
     id: pseudocode
     type: textarea
 
@@ -101,7 +101,7 @@ body:
         On the other end are systems where the possible solutions are very well defined, but it isn’t at all obvious how they could even be combined to achieve the goals. This may be a legacy system that is difficult to change and wasn’t designed to do what you want it to do or a library design that needs to operate within the constraints of the host programming language.
 
         In this situation you may be able to enumerate all the things you can do relatively easily, but you need to creatively put those things together to achieve the goals. There may be multiple solutions, and none of them are really great, and hence such a document should focus on selecting the best way given all identified trade-offs.
-      label: 'Degree of constraint'
+      label: "Degree of constraint"
     id: constrait
     type: textarea
 

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,8 +1,8 @@
 description:
-  'Suggest an idea for this project without a plan for implementation'
+  "Suggest an idea for this project without a plan for implementation"
 labels:
   - feat
-name: 'Feature Request'
+name: "Feature Request"
 body:
   - attributes:
       value: |
@@ -11,11 +11,11 @@ body:
         If you already have a plan to implement a feature or a change, please create a [design document](https://github.com/aeneasr/gh-template-test/issues/new?assignees=&labels=rfc&template=DESIGN-DOC.yml) instead if the change is non-trivial!
     type: markdown
   - attributes:
-      label: 'Preflight checklist'
+      label: "Preflight checklist"
       options:
         - label:
-            'I could not find a solution in the existing issues, docs, nor
-            discussions.'
+            "I could not find a solution in the existing issues, docs, nor
+            discussions."
           required: true
         - label:
             "I agree to follow this project's [Code of
@@ -26,18 +26,18 @@ body:
             Guidelines](https://github.com/ory/prettier-styles/blob/master/CONTRIBUTING.md)."
           required: true
         - label:
-            'This issue affects my [Ory Cloud](https://www.ory.sh/) project.'
+            "This issue affects my [Ory Cloud](https://www.ory.sh/) project."
         - label:
-            'I have joined the [Ory Community Slack](https://slack.ory.sh).'
+            "I have joined the [Ory Community Slack](https://slack.ory.sh)."
         - label:
-            'I am signed up to the [Ory Security Patch
-            Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53).'
+            "I am signed up to the [Ory Security Patch
+            Newsletter](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)."
     id: checklist
     type: checkboxes
   - attributes:
       description:
-        'Is your feature request related to a problem? Please describe.'
-      label: 'Describe your problem'
+        "Is your feature request related to a problem? Please describe."
+      label: "Describe your problem"
       placeholder:
         "A clear and concise description of what the problem is. Ex. I'm always
         frustrated when [...]"
@@ -50,20 +50,20 @@ body:
         Describe the solution you'd like
       placeholder: |
         A clear and concise description of what you want to happen.
-      label: 'Describe your ideal solution'
+      label: "Describe your ideal solution"
     id: solution
     type: textarea
     validations:
       required: true
   - attributes:
       description: "Describe alternatives you've considered"
-      label: 'Workarounds or alternatives'
+      label: "Workarounds or alternatives"
     id: alternatives
     type: textarea
     validations:
       required: true
   - attributes:
-      description: 'What version of our software are you running?'
+      description: "What version of our software are you running?"
       label: Version
     id: version
     type: input
@@ -71,7 +71,7 @@ body:
       required: true
   - attributes:
       description:
-        'Add any other context or screenshots about the feature request here.'
+        "Add any other context or screenshots about the feature request here."
       label: Additional Context
     id: additional
     type: textarea

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,3 +1,3 @@
 todo:
-  keyword: '@todo'
+  keyword: "@todo"
   label: todo

--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -2,13 +2,13 @@ name: Closed Reference Notifier
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       issueLimit:
         description: Max. number of issues to create
         required: true
-        default: '5'
+        default: "5"
 
 jobs:
   find_closed_references:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: "14"
       - uses: ory/closed-reference-notifier@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ on:
 jobs:
   btp:
     runs-on: ubuntu-latest
-    name: 'Build -> Test -> Publish'
+    name: "Build -> Test -> Publish"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm build
       - run: npm test

--- a/.github/workflows/release_tagger.yml
+++ b/.github/workflows/release_tagger.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: Actions-R-Us/actions-tagger@latest
         env:
-          GITHUB_TOKEN: '${{ github.token }}'
+          GITHUB_TOKEN: "${{ github.token }}"
         with:
           publish_latest_tag: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
-name: 'Close Stale Issues'
+name: "Close Stale Issues"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   stale:
@@ -35,10 +35,10 @@ jobs:
             Thank you for your understanding and to anyone who participated in the conversation! And as written above, please do participate in the conversation if this topic is important to you!
 
             Thank you 🙏✌️
-          stale-issue-label: 'stale'
-          exempt-issue-labels: 'bug,blocking,docs,backlog'
+          stale-issue-label: "stale"
+          exempt-issue-labels: "bug,blocking,docs,backlog"
           days-before-stale: 365
           days-before-close: 30
           exempt-milestones: true
           exempt-assignees: true
-          only-pr-labels: 'stale'
+          only-pr-labels: "stale"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: 'autogen(docs): formatting changes'
+          commit_message: "autogen(docs): formatting changes"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use the Prettier configuration with modifications, create a file
 
 ```js
 module.exports = {
-  ...require('ory-prettier-styles')
+  ...require("ory-prettier-styles"),
   // your custom Prettier settings here
 }
 ```

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,6 +3,6 @@ exports.__esModule = true
 var options = {
   proseWrap: "always",
   semi: false,
-  trailingComma: "none"
+  trailingComma: "all",
 }
 module.exports = options

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,9 +1,8 @@
-'use strict'
+"use strict"
 exports.__esModule = true
 var options = {
-  proseWrap: 'always',
+  proseWrap: "always",
   semi: false,
-  singleQuote: true,
-  trailingComma: 'none'
+  trailingComma: "none"
 }
 module.exports = options

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,10 +1,9 @@
-import * as prettier from 'prettier'
+import * as prettier from "prettier"
 
 const options: prettier.Options = {
-  proseWrap: 'always',
+  proseWrap: "always",
   semi: false,
-  singleQuote: true,
-  trailingComma: 'none'
+  trailingComma: "none"
 }
 
 module.exports = options

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -3,7 +3,7 @@ import * as prettier from "prettier"
 const options: prettier.Options = {
   proseWrap: "always",
   semi: false,
-  trailingComma: "none"
+  trailingComma: "all",
 }
 
 module.exports = options


### PR DESCRIPTION
Before I apply Prettier formatting consistently to all Ory repos (which will change a ton of files), I want to propose to remove the single-quote override for Prettier. Reasons:

- Most languages we use here only work with double-quotes: Go, JSON, HTML, CSS, English.
- Most JS tooling we use prefers double-quotes: Prettier, ESLint.
- TS and YML can use either form but [chose to deviate from the other languages we use](https://youtu.be/vIJHp_y2PE8). That feels elitist 🙂 
- I see consistency in code style across Ory as more important than conforming to (arbitrary) external style standards. Since we are a Go company, let's make our JS style match that of Go: no semi and double quotes for strings.
- Most of the YML at Ory already uses double-quotes, let's not change that.
- With the current config, TSX often has [both types of quotes on a single line](https://github.com/ory/docs/blob/master/docs/hydra/guides/consent.mdx?plain=1#L84). That looks odd.

I am therefore proposing to remove the `singleQuote: true` override from the Ory-wide Prettier config. I think the benefit of removing pointless edge cases is worth the change. Curious what you think! No hard feelings if anybody sees it differently. 